### PR TITLE
Add call to super in after_teardown

### DIFF
--- a/lib/minitest/stately/after_teardown.rb
+++ b/lib/minitest/stately/after_teardown.rb
@@ -2,6 +2,7 @@ module Minitest
   module Stately
     module AfterTeardown
       def after_teardown
+        super
         Minitest::Stately.watcher.record(self)
       end
     end


### PR DESCRIPTION
Ensure that if Stately is loaded before Mocha (or anything that uses an `after_teardown`), the ones that come after are run correctly.

This specifically came up for me with Rails 5.1.3 and Mocha. Mocha relies on an `after_teardown` that is prevented from being called.

@jasonrclark @rafaelfranca @alanwushopify